### PR TITLE
Have it return the replicated movement speed

### DIFF
--- a/MultiplayerMovementPlugin/Source/MultiplayerMovementPlugin/Private/MyCharacterMovementComponent.cpp
+++ b/MultiplayerMovementPlugin/Source/MultiplayerMovementPlugin/Private/MyCharacterMovementComponent.cpp
@@ -125,8 +125,7 @@ float UMyCharacterMovementComponent::GetMaxSpeed() const
             //Called When Falling 
             case MOVE_Falling:
                 {
-                    
-                    return 600.f; 
+                    return MaxGroundSpeed; 
                 }
 
         case MOVE_Swimming:


### PR DESCRIPTION
Are you not sending the WalkSpeed to the server when it's in the air state? If you are, then this shouldn't cause any errors and would be preferred instead of a flat float value. Let me know if that's okay or what needs to be implemented to fix this, I wanna implement this for bhopping!